### PR TITLE
Set gsof proto name

### DIFF
--- a/gsof.lua
+++ b/gsof.lua
@@ -242,6 +242,7 @@ end
 
 -- GSOF Subdissector Function
 function gsof_proto.dissector(buffer, pinfo, tree)
+    pinfo.cols.protocol = gsof_proto.name
     local offset = 0
     local gsof_tree = tree:add(gsof_proto, buffer(), "GSOF Records")
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7d20e764-6c5a-4d3e-ba2b-adeebb716277)


Sets the name to GSOF in the protocol column